### PR TITLE
Improve batch one-liner JSON parsing

### DIFF
--- a/tests/test_one_liners_batch.py
+++ b/tests/test_one_liners_batch.py
@@ -1,0 +1,55 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+requests_stub = types.ModuleType("requests")
+requests_stub.post = lambda *a, **k: None
+requests_stub.get = lambda *a, **k: None
+requests_stub.RequestException = Exception
+requests_stub.Response = type("Response", (), {})
+sys.modules.setdefault("requests", requests_stub)
+
+import appv2
+
+
+def test_openrouter_batch_parses_json_with_fences_and_noise():
+    client = appv2.OpenRouterClient(api_key="key", model="model", debug=True)
+
+    def fake_post(payload):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": "Intro text\n```json\n[\"one\", \"two\"]\n```\nOutro"
+                    }
+                }
+            ]
+        }
+
+    client._post = fake_post
+    items = [("customer", "a"), ("agent", "b")]
+    assert client.summarise_one_liners_batch(items) == ["one", "two"]
+
+
+def test_openai_batch_parses_json_with_fences_and_noise():
+    client = appv2.OpenAIClient(api_key="key", model="model", debug=True)
+
+    class Resp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "Here\n```json\n[\"x\", \"y\"]\n```\nThanks"
+                        }
+                    }
+                ]
+            }
+
+    client._post_with_backoff = lambda url, payload, label: Resp()
+    items = [("customer", "c"), ("agent", "d")]
+    assert client.summarise_one_liners_batch(items) == ["x", "y"]


### PR DESCRIPTION
## Summary
- Strip code fences and use safe parsing for batched one-liner outputs
- Enhance `_safe_json_parse` to recover arrays from noisy responses
- Test batch parsing with code fences and surrounding text for both clients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c749611b70832ea43df83d48945b9c