### PR TITLE
Handle fenced JSON blocks in summaries

### DIFF
--- a/appv2.py
+++ b/appv2.py
@@ -402,7 +402,8 @@ class OpenRouterClient:
 
     @staticmethod
     def _strip_code_fences(s: str) -> str:
-        return re.sub(r"^```(?:json)?\s*|\s*```$", "", s.strip(), flags=re.I|re.M)
+        m = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", s or "", re.I)
+        return m.group(1) if m else s
 
     def _post(self, payload: dict) -> Optional[dict]:
         for i in range(5):
@@ -767,7 +768,8 @@ class OpenAIClient:
     # -------------- Parse helpers --------------
     @staticmethod
     def _strip_code_fences(s: str) -> str:
-        return re.sub(r"^```(?:json)?\s*|\s*```$", "", (s or "").strip(), flags=re.I | re.M)
+        m = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", s or "", re.I)
+        return m.group(1) if m else s
 
     @staticmethod
     def _extract_responses_text(data: dict) -> str:

--- a/tests/test_one_liners_batch.py
+++ b/tests/test_one_liners_batch.py
@@ -22,7 +22,7 @@ def test_openrouter_batch_parses_json_with_fences_and_noise():
             "choices": [
                 {
                     "message": {
-                        "content": "Intro text\n```json\n[\"one\", \"two\"]\n```\nOutro"
+                        "content": "Intro [0]\n```json\n[\"one\", \"two\"]\n```\nOutro {ignored}"
                     }
                 }
             ]
@@ -44,7 +44,7 @@ def test_openai_batch_parses_json_with_fences_and_noise():
                 "choices": [
                     {
                         "message": {
-                            "content": "Here\n```json\n[\"x\", \"y\"]\n```\nThanks"
+                            "content": "Pre [noise]\n```json\n[\"x\", \"y\"]\n```\nPost {junk}"
                         }
                     }
                 ]


### PR DESCRIPTION
## Summary
- Improve `_strip_code_fences` to extract the first fenced block anywhere in the string for both OpenRouterClient and OpenAIClient
- Ensure batch one-liner parsers test parsing when fenced JSON is surrounded by extra text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74c77c364832ebe4203c0aed09c78